### PR TITLE
memory leak quick fix

### DIFF
--- a/PassportScanner.xcodeproj/project.pbxproj
+++ b/PassportScanner.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 				TargetAttributes = {
 					7F132F2D1B9ED2C5001A542A = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = 6Z7QY98HTS;
+						DevelopmentTeam = KPGBP53N38;
 						LastSwiftMigration = 0800;
 					};
 				};
@@ -194,6 +194,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -402,16 +403,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 6Z7QY98HTS;
+				DEVELOPMENT_TEAM = KPGBP53N38;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = PassportScanner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Pods/TesseractOCRiOS/TesseractOCR/lib",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = nl.evict.PassportScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = "PassportScanner-leak";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "PassportScanner/PassportScanner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -425,16 +426,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 6Z7QY98HTS;
+				DEVELOPMENT_TEAM = KPGBP53N38;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = PassportScanner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Pods/TesseractOCRiOS/TesseractOCR/lib",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = nl.evict.PassportScanner;
+				PRODUCT_BUNDLE_IDENTIFIER = "PassportScanner-leak";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "PassportScanner/PassportScanner-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;

--- a/PassportScanner/Info.plist
+++ b/PassportScanner/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>For scanning your passport</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -43,7 +45,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string>For scanning your passport</string>
 </dict>
 </plist>

--- a/Pod/PassportScannerController.swift
+++ b/Pod/PassportScannerController.swift
@@ -84,7 +84,7 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
     var pictureOutput = PictureOutput()
     
     /// The tesseract OCX engine
-    var tesseract: MGTesseract = MGTesseract(language: "eng")
+    var tesseract: MGTesseract? = MGTesseract(language: "eng")
     
     /**
      Rotation is not needed.
@@ -186,22 +186,22 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
         // optimisations created based on https://github.com/gali8/Tesseract-OCR-iOS/wiki/Tips-for-Improving-OCR-Results
         
         // tesseract OCR settings
-        self.tesseract.setVariableValue("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ<", forKey: "tessedit_char_whitelist")
-        self.tesseract.delegate = self
+        self.tesseract?.setVariableValue("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ<", forKey: "tessedit_char_whitelist")
+        self.tesseract?.delegate = self
         
-        self.tesseract.rect = CGRect(x: 0, y: 0, width: ocrParsingRect.size.height / 2, height: ocrParsingRect.size.width / 2)
+        self.tesseract?.rect = CGRect(x: 0, y: 0, width: ocrParsingRect.size.height / 2, height: ocrParsingRect.size.width / 2)
         
         // see http://www.sk-spell.sk.cx/tesseract-ocr-en-variables
-        self.tesseract.setVariableValue("1", forKey: "tessedit_serial_unlv")
-        self.tesseract.setVariableValue("FALSE", forKey: "x_ht_quality_check")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_system_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_freq_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_unambig_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_punc_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_number_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_fixed_length_dawgs")
-        self.tesseract.setVariableValue("FALSE", forKey: "load_bigram_dawg")
-        self.tesseract.setVariableValue("FALSE", forKey: "wordrec_enable_assoc")
+        self.tesseract?.setVariableValue("1", forKey: "tessedit_serial_unlv")
+        self.tesseract?.setVariableValue("FALSE", forKey: "x_ht_quality_check")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_system_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_freq_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_unambig_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_punc_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_number_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_fixed_length_dawgs")
+        self.tesseract?.setVariableValue("FALSE", forKey: "load_bigram_dawg")
+        self.tesseract?.setVariableValue("FALSE", forKey: "wordrec_enable_assoc")
     }
     
     open override func viewDidAppear(_ animated: Bool) {
@@ -321,7 +321,7 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
         
         crop.cropSizeInPixels = Size(width: Float(ocrParsingRect.size.width), height: Float(ocrParsingRect.size.height))
         crop.locationOfCropInPixels = Position(Float(ocrParsingRect.origin.x), Float(ocrParsingRect.origin.y), nil)
-        self.tesseract.rect = CGRect(x: 0, y: 0, width: ocrParsingRect.size.height / 2, height: ocrParsingRect.size.width / 2)
+        self.tesseract?.rect = CGRect(x: 0, y: 0, width: ocrParsingRect.size.height / 2, height: ocrParsingRect.size.width / 2)
         
     }
     
@@ -369,6 +369,7 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
     @objc public func stopScan() {
         self.view.backgroundColor = UIColor.white
         camera.stopCapture()
+        tesseract = nil
         abortScan()
     }
     
@@ -472,11 +473,11 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
     open func doOCR(image: UIImage) -> String {
         // Start OCR
         var result: String?
-        self.tesseract.image = image
+        self.tesseract?.image = image
         
         print("- Start recognize")
-        self.tesseract.recognize()
-        result = self.tesseract.recognizedText
+        self.tesseract?.recognize()
+        result = self.tesseract?.recognizedText
         //tesseract = nil
         MGTesseract.clearCache()
         print("Scan result : \(result ?? "")")
@@ -505,6 +506,11 @@ open class PassportScannerController: UIViewController, MGTesseractDelegate {
         }else{
             assertionFailure("You should overwrite this function to handle an abort")
         }
+    }
+    
+    open override func viewWillDisappear(_ animated: Bool) {
+        tesseract = nil
+        super.viewWillDisappear(animated)
     }
 }
 


### PR DESCRIPTION
Ended up with just assigning `nil` to tesseract variable in `viewWillDissappear` method. Seems that  it fixes the issue with deallocating memory after scan (either successful with result or aborted by a user).